### PR TITLE
Display length of authentication and recovery code in mat error

### DIFF
--- a/src/app/sign-in/components/two-factor/two-factor.component.html
+++ b/src/app/sign-in/components/two-factor/two-factor.component.html
@@ -17,20 +17,33 @@
     <mat-hint align="end"
       >{{ inputVerificationCode.value?.length || 0 }}/6</mat-hint
     >
-
     <mat-error
-      i18n="@@ngOrcid.signin.2fa.verificationCodeRequired"
       *ngIf="verificationFormControl.hasError('required')"
-      >Authentication code is required
+      >
+        <p
+          i18n="@@ngOrcid.signin.2fa.verificationCodeRequired"
+          class="error-message">
+          Authentication code is required
+        </p>
+        <p class="error-length">
+          {{ inputVerificationCode.value?.length || 0 }}/6
+        </p>
     </mat-error>
 
     <mat-error
-      i18n="@@ngOrcid.signin.2fa.badVerificationCodeLength"
       *ngIf="
         verificationFormControl.hasError('minlength') ||
         verificationFormControl.hasError('maxlength')
       "
-      >Invalid authentication code length
+    >
+        <p
+        i18n="@@ngOrcid.signin.2fa.badVerificationCodeLength"
+        class="error-message">
+        Invalid authentication code length
+        </p>
+        <p class="error-length">
+            {{ inputVerificationCode.value?.length || 0 }}/6
+        </p>
     </mat-error>
   </mat-form-field>
   <p>
@@ -81,18 +94,32 @@
       >{{ inputRecoveryCode.value?.length || 0 }}/10</mat-hint
     >
     <mat-error
-      i18n="@@ngOrcid.signin.2fa.recoveryCodeRequired"
       *ngIf="recoveryCodeFormControl.hasError('required')"
-      >Recovery code is required
+      >
+        <p
+          i18n="@@ngOrcid.signin.2fa.recoveryCodeRequired"
+          class="error-message">
+          Recovery code is required
+        </p>
+        <p class="error-length">
+          {{ inputRecoveryCode.value?.length || 0 }}/10
+        </p>
     </mat-error>
 
     <mat-error
-      i18n="@@ngOrcid.signin.2fa.badRecoveryCodeLength"
       *ngIf="
         recoveryCodeFormControl.hasError('minlength') ||
         recoveryCodeFormControl.hasError('maxlength')
       "
-      >Invalid recovery code length
+      >
+        <p
+          i18n="@@ngOrcid.signin.2fa.badRecoveryCodeLength"
+          class="error-message">
+          Invalid recovery code length
+        </p>
+        <p class="error-length">
+          {{ inputRecoveryCode.value?.length || 0 }}/10
+        </p>
     </mat-error>
   </mat-form-field>
 

--- a/src/app/sign-in/components/two-factor/two-factor.component.scss
+++ b/src/app/sign-in/components/two-factor/two-factor.component.scss
@@ -6,6 +6,16 @@
   margin-top: 12px;
 }
 
+.error-message {
+  float: left;
+  margin: 0;
+}
+
+.error-length {
+  float: right;
+  margin: 0;
+}
+
 .orcid-error {
   margin-top: 20px !important;
 }

--- a/src/app/sign-in/components/two-factor/two-factor.component.scss
+++ b/src/app/sign-in/components/two-factor/two-factor.component.scss
@@ -1,3 +1,7 @@
+:host {
+  width: 100%;
+}
+
 .mat-button-font {
   margin: auto;
 }
@@ -9,11 +13,17 @@
 .error-message {
   float: left;
   margin: 0;
+  [dir='rtl'] :host & {
+    float: right;
+  }
 }
 
 .error-length {
   float: right;
   margin: 0;
+  [dir='rtl'] :host & {
+    float: left;
+  }
 }
 
 .orcid-error {


### PR DESCRIPTION
https://trello.com/c/r0gAeSRZ/6725-qa-signin-2fa-character-counter-disappears-when-error-message-is-displayed