### PR TITLE
Fix go back button institutional sign in

### DIFF
--- a/src/app/institutional/pages/institutional/institutional.component.html
+++ b/src/app/institutional/pages/institutional/institutional.component.html
@@ -86,7 +86,7 @@
                 </mat-form-field>
                 <div class="institutional-buttons">
                   <a
-                    class="mat-button-font go-back"
+                    class="mat-button-font"
                     i18n="@@institutional.goBack"
                     [routerLink]="['/signin']"
                     >Go back

--- a/src/app/institutional/pages/institutional/institutional.component.scss
+++ b/src/app/institutional/pages/institutional/institutional.component.scss
@@ -17,12 +17,8 @@ button {
 
 .institutional-buttons {
   display: flex;
+  align-items: center;
   justify-content: space-between;
-}
-
-.go-back {
-  margin-top: auto;
-  margin-bottom: auto;
 }
 
 .remove-border {


### PR DESCRIPTION
https://trello.com/c/BOFJNdAv/6803-qa-signin-institutional-signin-go-back-button-is-not-aligned-properly-on-ie11