### PR TITLE
Overwrite chrome and edge input autofill colors

### DIFF
--- a/src/assets/scss/material.light-theme.scss
+++ b/src/assets/scss/material.light-theme.scss
@@ -15,13 +15,14 @@
   $background: map_merge(
     $background,
     (
-      // COLORS ADDED
+      // COLORS ADDED
         app-news: $dark-primary-background,
       light-grey: $light-grey,
       grey: $grey,
       blue-overlay: $blue-overlay,
       dark-grey: $dark-grey-background,
-      // COLORS OVERWRITES
+      autofill-input: white,
+      // COLORS OVERWRITES
         unselected-chip: white
     )
   );

--- a/src/assets/scss/material.orcid.overwrites.scss/_form-field-outline-theme.scss
+++ b/src/assets/scss/material.orcid.overwrites.scss/_form-field-outline-theme.scss
@@ -5,14 +5,16 @@
 
 @mixin mat-form-field-outline-theme-overwrites($theme) {
   $foreground: map-get($theme, foreground);
+  $background: map-get($theme, background);
   .mat-form-field-appearance-outline {
-    input {
-      // use material mixing to overwrite the autofill
-      // https://material.angular.io/cdk/text-field/overview#styling-the-autofill-state-of-an-code-lt-input-gt-code-
-      @include cdk-text-field-autofill-color(
-        transparent,
-        mat-color($foreground, mat-color($foreground, text))
-      );
+    input:-webkit-autofill,
+    input:-webkit-autofill:hover,
+    input:-webkit-autofill:focus,
+    input:-webkit-autofill:active {
+      -webkit-box-shadow: 0 0 0 30px map-get($background, autofill-input) inset !important;
+    }
+    input.edge-autofilled {
+      background-color: map-get($background, autofill-input) !important;
     }
   }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -122,7 +122,3 @@ input[type='reset'] {
 html {
   overflow-y: scroll;
 }
-
-input.edge-autofilled {
-  background-color: transparent !important;
-}


### PR DESCRIPTION
Add a new color to the background theme and overwrites chrome and edge input autofill colors