### PR TITLE
Atemp to disable autocompletes on email confirmation

### DIFF
--- a/src/app/register/components/form-personal/form-personal.component.html
+++ b/src/app/register/components/form-personal/form-personal.component.html
@@ -86,12 +86,15 @@
       <mat-label i18n="@@register.confirmEmail"
         >Confirm primary email</mat-label
       >
+      <!-- "confirm-email" is no really a valid autocomplete valid
+      but it should avoid some browsers like edge chromium to suggest the user email 
+      on this confirmation field  -->
       <input
         formControlName="confirmEmail"
         matInput
         (paste)="(false)"
         appTrim
-        autocomplete="off"
+        autocomplete="confirm-email"
         type="email"
       />
       <mat-error


### PR DESCRIPTION
**Coping the same last message a put on the Trello card here:**


Unfortunately, disabling this is not really a supported feature on any major browser 
https://caniuse.com/#feat=input-autocomplete-onoff, and there are many open discussions about
 why and why not should browsers allow developers to disable autocompletes...

And there is a lot of info about why the "retype email" is bad UX...

But to avoid going too deep with this one, I would like to try one more thing that seems
 to be working for me.
