### PR TITLE
fix `For Researchers` menu link

### DIFF
--- a/src/app/layout/header/menu.ts
+++ b/src/app/layout/header/menu.ts
@@ -3,7 +3,7 @@ export const menu: ApplicationMenuItemBasic[] = [
   {
     id: 'public-layout.for_researchers',
     label: $localize`:@@public-layout.for_researchers:For Researchers`,
-    route: 'about/what-is-orcid/mission',
+    route: 'help',
     activeRoute: '/',
     requirements: {
       togglz: { NEW_INFO_SITE: 'false' },


### PR DESCRIPTION
https://trello.com/c/vhIi0EWh/6924-for-researchers-menu-link-goes-to-different-pages-depending-on-what-site-youre-on-when-you-click-it