### PR TITLE
fix oauth ORCID id url

### DIFF
--- a/src/app/authorize/pages/authorize/authorize.component.html
+++ b/src/app/authorize/pages/authorize/authorize.component.html
@@ -34,7 +34,9 @@
               <div class="mat-body-2">
                 <strong>{{ userName }}</strong>
               </div>
-              <a class="mat-button-font" href="{{ orcidUrl }}">{{ orcidUrl }}</a>
+              <a class="mat-button-font" href="{{ orcidUrl }}">{{
+                orcidUrl
+              }}</a>
             </div>
             <div c class="mat-body-2 user-links m-b-8">
               <a

--- a/src/app/authorize/pages/authorize/authorize.component.html
+++ b/src/app/authorize/pages/authorize/authorize.component.html
@@ -34,7 +34,7 @@
               <div class="mat-body-2">
                 <strong>{{ userName }}</strong>
               </div>
-              <div class="mat-body-2">{{ orcidUrl }}</div>
+              <a class="mat-button-font" href="{{ orcidUrl }}">{{ orcidUrl }}</a>
             </div>
             <div c class="mat-body-2 user-links m-b-8">
               <a


### PR DESCRIPTION
https://trello.com/c/F4kod5eF/6997-qa-oauth-orcid-id-should-be-displayed-as-full-url