### PR TITLE
fix oauth redirect to register form if email doesnt exists

### DIFF
--- a/src/app/guards/sign-in.guard.ts
+++ b/src/app/guards/sign-in.guard.ts
@@ -57,6 +57,12 @@ export class SignInGuard implements CanActivateChild {
     // check if the user is already login or there are errors
     return this._user.getUserSession(queryParams).pipe(
       map((session) => {
+        if (queryParams.email && !session.oauthSession.userId) {
+          return this._router.createUrlTree(['/register'], {
+            queryParams: queryParams,
+          })
+        }
+
         const oauthSession = session.oauthSession
         if (
           oauthSession &&

--- a/src/app/register/pages/register/register.component.ts
+++ b/src/app/register/pages/register/register.component.ts
@@ -283,6 +283,7 @@ export class RegisterComponent implements OnInit, AfterViewInit {
           familyNames: value.userFamilyNames || value['lastName'] || '',
           emails: {
             email: value.userEmail || value['email'] || '',
+            confirmEmail: '',
             additionalEmails: { '0': '' },
           },
         },


### PR DESCRIPTION
https://trello.com/c/UklUsRR3/6978-qa-authorization-url-with-email-address-that-doesnt-exist-in-the-db-should-display-the-register-screen