### PR TITLE
fix oauth redirect to register if orcid id doesnt exist in db

### DIFF
--- a/src/app/guards/sign-in.guard.ts
+++ b/src/app/guards/sign-in.guard.ts
@@ -50,7 +50,7 @@ export class SignInGuard implements CanActivateChild {
     return this._user.getUserSession(queryParams).pipe(
       map((session) => {
         if (
-          queryParams.email &&
+          (queryParams.email || queryParams.orcid) &&
           session.oauthSession &&
           !session.oauthSession.userId
         ) {


### PR DESCRIPTION
https://trello.com/c/qbSLbU6R/6979-qa-authorization-url-with-orcid-id-that-doesnt-exist-should-display-register-screen