### PR TITLE
fix urlsearchparams in ie11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7568,9 +7568,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.6.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/gtag.js": "^0.0.3",
     "browserslist": "^4.9.1",
     "browserslist-useragent-regexp": "^2.0.1",
-    "core-js": "^2.6.9",
+    "core-js": "^3.6.5",
     "css-loader": "^3.2.0",
     "firebase": "^7.6.0",
     "ngx-cookie-service": "^3.0.3",

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -63,4 +63,5 @@ import '@angular/localize/init'
 import 'zone.js/dist/zone' // Included with Angular CLI.
 // tslint:disable-next-line:whitespace
 ;(window as any)['global'] = window
-import 'core-js/es7/string'
+import 'core-js/es/string'
+import 'core-js/features/url-search-params';

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -64,4 +64,4 @@ import 'zone.js/dist/zone' // Included with Angular CLI.
 // tslint:disable-next-line:whitespace
 ;(window as any)['global'] = window
 import 'core-js/es/string'
-import 'core-js/features/url-search-params';
+import 'core-js/features/url-search-params'


### PR DESCRIPTION
fix URLSearchParams in ie11 and upgrade to core-js@3 since core-js@2 is obsolete