### PR TITLE
fix removing parameters in institutional/social oauth

### DIFF
--- a/src/app/link-account/pages/link-account/link-account.component.ts
+++ b/src/app/link-account/pages/link-account/link-account.component.ts
@@ -95,9 +95,9 @@ export class LinkAccountComponent implements OnInit {
         this._router.navigate([ApplicationRoutes.signin], {
           queryParams: {
             ...params,
-            email: (params.email ? params.email : undefined),
-            firstName: (params.firstName ? params.firstName : undefined),
-            lastName: (params.lastName ? params.lastName : undefined),
+            email: params.email ? params.email : undefined,
+            firstName: params.firstName ? params.firstName : undefined,
+            lastName: params.lastName ? params.lastName : undefined,
             linkType: undefined,
             providerId: undefined,
           },

--- a/src/app/link-account/pages/link-account/link-account.component.ts
+++ b/src/app/link-account/pages/link-account/link-account.component.ts
@@ -91,20 +91,15 @@ export class LinkAccountComponent implements OnInit {
       .get()
       .pipe(first())
       .subscribe((platform) => {
+        const params = platform.queryParameters
         this._router.navigate([ApplicationRoutes.signin], {
           queryParams: {
-            ...platform.queryParameters,
-            // The parameters added after a linking + register process are remove
-
-            // TODO leomendoza123
-            // Adding the social/institutional parameters on the URL causes issues
-            // https://trello.com/c/EiZOE6b1/7138
-
-            email: null,
-            firstName: null,
-            lastName: null,
-            linkType: null,
-            providerId: null,
+            ...params,
+            email: (params.email ? params.email : undefined),
+            firstName: (params.firstName ? params.firstName : undefined),
+            lastName: (params.lastName ? params.lastName : undefined),
+            linkType: undefined,
+            providerId: undefined,
           },
         })
       })

--- a/src/app/register/pages/register/register.component.ts
+++ b/src/app/register/pages/register/register.component.ts
@@ -99,10 +99,6 @@ export class RegisterComponent implements OnInit, AfterViewInit {
 
           // TODO @leomendoza123 move the handle of social/institutional sessions to the user service
 
-          // TODO leomendoza123
-          // Adding the social/institutional parameters on the URL causes issues
-          // https://trello.com/c/EiZOE6b1/7138
-
           if (platform.queryParameters.providerId) {
             this.FormGroupStepA = this.prefillRegisterForm(
               this.platform.queryParameters

--- a/src/app/sign-in/components/form-sign-in/form-sign-in.component.ts
+++ b/src/app/sign-in/components/form-sign-in/form-sign-in.component.ts
@@ -263,12 +263,11 @@ export class FormSignInComponent implements OnInit, AfterViewInit {
               .subscribe((userSession) => {
                 const params = platform.queryParameters
                 this._router.navigate(['/register'], {
-
                   queryParams: {
                     ...params,
-                    email: (params.email ? params.email : email),
-                    firstName: (params.firstName ? params.firstName : firstName),
-                    lastName: (params.lastName ? params.lastName : lastName),
+                    email: params.email ? params.email : email,
+                    firstName: params.firstName ? params.firstName : firstName,
+                    lastName: params.lastName ? params.lastName : lastName,
                     providerId,
                     linkType,
                   },

--- a/src/app/sign-in/components/form-sign-in/form-sign-in.component.ts
+++ b/src/app/sign-in/components/form-sign-in/form-sign-in.component.ts
@@ -263,15 +263,12 @@ export class FormSignInComponent implements OnInit, AfterViewInit {
               .subscribe((userSession) => {
                 const params = platform.queryParameters
                 this._router.navigate(['/register'], {
-                  // TODO leomendoza123
-                  // Adding the social/institutional parameters on the URL causes issues
-                  // https://trello.com/c/EiZOE6b1/7138
 
                   queryParams: {
                     ...params,
-                    email,
-                    firstName,
-                    lastName,
+                    email: (params.email ? params.email : email),
+                    firstName: (params.firstName ? params.firstName : firstName),
+                    lastName: (params.lastName ? params.lastName : lastName),
                     providerId,
                     linkType,
                   },


### PR DESCRIPTION
https://trello.com/c/EiZOE6b1/7138-oauth-urls-with-email-a-cancelled-account-link-registrations-will-remove-the-email-parameter-from-the-oauth-url