### PR TITLE
Fix error when loading the edit form the ext id value and url were empty

### DIFF
--- a/src/app/record/components/funding-stacks-groups/modals/modal-funding/modal-funding.component.ts
+++ b/src/app/record/components/funding-stacks-groups/modals/modal-funding/modal-funding.component.ts
@@ -186,13 +186,7 @@ export class ModalFundingComponent implements OnInit, OnDestroy {
       country: new FormControl(this.country, {
         validators: [Validators.required],
       }),
-      grants: new FormArray([
-        this._formBuilder.group({
-          grantNumber: ['', []],
-          grantUrl: ['', [Validators.pattern(URL_REGEXP)]],
-          fundingRelationship: [FundingRelationships.self, []],
-        }),
-      ]),
+      grants: new FormArray([]),      
       visibility: new FormControl(this.visibility, {
         validators: [Validators.required],
       }),
@@ -220,17 +214,29 @@ export class ModalFundingComponent implements OnInit, OnDestroy {
 
     this.grantsArray = this.fundingForm.controls.grants as FormArray
     let i = 0
-    this.funding?.externalIdentifiers?.forEach((extIdentifier) => {
+    if(this.funding?.externalIdentifiers?.length > 0) {
+      this.funding.externalIdentifiers.forEach((extIdentifier) => {
+        this.grantsArray.controls.push(
+          this._formBuilder.group({
+            grantNumber: [extIdentifier.externalIdentifierId?.value, []],
+            grantUrl: [extIdentifier.url?.value, [Validators.pattern(URL_REGEXP)]],
+            fundingRelationship: [extIdentifier.relationship.value, []],
+          })
+        )
+        this.checkGrantsChanges(i)
+        i++
+      })
+    } else {
       this.grantsArray.controls.push(
         this._formBuilder.group({
-          grantNumber: [extIdentifier.externalIdentifierId.value, []],
-          grantUrl: [extIdentifier.url.value, [Validators.pattern(URL_REGEXP)]],
-          fundingRelationship: [extIdentifier.relationship.value, []],
-        })
+          grantNumber: ['', []],
+          grantUrl: ['', [Validators.pattern(URL_REGEXP)]],
+          fundingRelationship: [FundingRelationships.self, []],
+        }),
       )
       this.checkGrantsChanges(i)
-      i++
-    })
+    }
+    
 
     this._recordCountryService
       .getCountryCodes()

--- a/src/app/record/components/funding-stacks-groups/modals/modal-funding/modal-funding.component.ts
+++ b/src/app/record/components/funding-stacks-groups/modals/modal-funding/modal-funding.component.ts
@@ -186,7 +186,7 @@ export class ModalFundingComponent implements OnInit, OnDestroy {
       country: new FormControl(this.country, {
         validators: [Validators.required],
       }),
-      grants: new FormArray([]),      
+      grants: new FormArray([]),
       visibility: new FormControl(this.visibility, {
         validators: [Validators.required],
       }),
@@ -214,12 +214,15 @@ export class ModalFundingComponent implements OnInit, OnDestroy {
 
     this.grantsArray = this.fundingForm.controls.grants as FormArray
     let i = 0
-    if(this.funding?.externalIdentifiers?.length > 0) {
+    if (this.funding?.externalIdentifiers?.length > 0) {
       this.funding.externalIdentifiers.forEach((extIdentifier) => {
         this.grantsArray.controls.push(
           this._formBuilder.group({
             grantNumber: [extIdentifier.externalIdentifierId?.value, []],
-            grantUrl: [extIdentifier.url?.value, [Validators.pattern(URL_REGEXP)]],
+            grantUrl: [
+              extIdentifier.url?.value,
+              [Validators.pattern(URL_REGEXP)],
+            ],
             fundingRelationship: [extIdentifier.relationship.value, []],
           })
         )
@@ -232,11 +235,10 @@ export class ModalFundingComponent implements OnInit, OnDestroy {
           grantNumber: ['', []],
           grantUrl: ['', [Validators.pattern(URL_REGEXP)]],
           fundingRelationship: [FundingRelationships.self, []],
-        }),
+        })
       )
       this.checkGrantsChanges(i)
     }
-    
 
     this._recordCountryService
       .getCountryCodes()


### PR DESCRIPTION
Two issues fixed here: 

- When trying to edit on Funding, due to a null pointer execption, if id value or url were empty, the form doesn't display any external id value
- When the funding comes with one or more externa identifiers, the first one was always empty, because the array contains one empty element by default