### PR TITLE
Fixed double spacing for translation title

### DIFF
--- a/src/app/record/components/work/work.component.html
+++ b/src/app/record/components/work/work.component.html
@@ -44,9 +44,8 @@
       <span class="translated-title-label orc-font-body-small">
         <ng-container i18n="@@works.translatedTitle"
           >Translated title</ng-container
-        > </span
-      >&nbsp;
-      <ng-container *ngIf="work.translatedTitle?.languageName">
+        >&nbsp;</span
+      ><ng-container *ngIf="work.translatedTitle?.languageName">
         ({{ work.translatedTitle.languageName }})
       </ng-container>
     </div>


### PR DESCRIPTION
@leomendoza123  the component has the preserve white spaces in ts but it doesn't preserve it if I don't explicitly add nbsp