### PR TITLE
Improve date validatio

### DIFF
--- a/src/app/shared/validators/date/date.validator.ts
+++ b/src/app/shared/validators/date/date.validator.ts
@@ -71,9 +71,12 @@ export function dateMonthYearValidator(dateType: string) {
 
 export function endDateMonthYearValidator() {
   return (c: AbstractControl): { [key: string]: any } | null => {
-
-    const endDateExistingErrors = Object.keys(c.get('endDateGroup').errors || {})
-    const startDateExistingErrors = Object.keys(c.get('startDateGroup').errors|| {})
+    const endDateExistingErrors = Object.keys(
+      c.get('endDateGroup').errors || {}
+    )
+    const startDateExistingErrors = Object.keys(
+      c.get('startDateGroup').errors || {}
+    )
     if (endDateExistingErrors.length || startDateExistingErrors.length) {
       // both date has to be valid to validate end date congruence
       return null
@@ -116,9 +119,12 @@ export function endDateMonthYearValidator() {
 
 export function endDateValidator() {
   return (c: AbstractControl): { [key: string]: any } | null => {
-
-    const endDateExistingErrors = Object.keys(c.get('endDateGroup').errors || {})
-    const startDateExistingErrors = Object.keys(c.get('startDateGroup').errors || {})
+    const endDateExistingErrors = Object.keys(
+      c.get('endDateGroup').errors || {}
+    )
+    const startDateExistingErrors = Object.keys(
+      c.get('startDateGroup').errors || {}
+    )
     if (endDateExistingErrors.length || startDateExistingErrors.length) {
       // both date has to be valid to validate end date congruence
       return null


### PR DESCRIPTION
Apart from fixing the explorer error this PR will fix the following issue: 


BEFORE: 
When the start and end year are the same.  And the end month is defined, but the start month is not defined. 
The save button will close the modals but the item won't be updated. This applies for affiliations and fundings. 


<img width="305" alt="Screen Shot 2021-11-11 at 13 00 41" src="https://user-images.githubusercontent.com/2119626/141354815-2e704c52-1c9b-4095-88ee-777fddca8143.png">

NOW: 

The same error state of the old app will be shown, and the user can't save the form
<img width="303" alt="Screen Shot 2021-11-11 at 13 06 56" src="https://user-images.githubusercontent.com/2119626/141354834-c254f37c-7068-46e3-9137-8812c2d59b29.png">


