### PR TITLE
Fix supported browsers list to match currently supported browsers

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,11 +1,11 @@
 # You can see what browsers were selected by your queries by running:
 #   npx browserslist
 
-and_ff > 87, 
-chrome > 80, 
-edge > 89, 
-firefox > 78, 
-ios_saf > 13, 
-opera > 74, 
-safari > 13, 
-and_chr > 80
+and_ff >= 87, 
+and_chr >= 80
+chrome >= 80, 
+edge >= 89, 
+firefox >= 78, 
+ios_saf >= 13.4, 
+opera >= 74, 
+safari >= 13.1, 


### PR DESCRIPTION
### THE NEW LIST OF SUPPORT BROWSERS 

```
Android Firefox 96 (or newer)
Chrome 80 (or newer)
Edge 89 (or newer)
Firefox 78 (or newer)
IOS Safari 13.4-13.7 (or newer)
Opera 74 (or newer)
Safari 13.1 (or newer)
Android chrome  97 (or newer)
```
