### PR TITLE
7842 rors are included in search for the UI and the api 

### DIFF
--- a/src/app/core/search/search.service.ts
+++ b/src/app/core/search/search.service.ts
@@ -93,12 +93,11 @@ export class SearchService {
           searchParameters.push(`ringgold-org-id:${escapedParams.institution}`)
         } else if (escapedParams.institution.startsWith('grid.')) {
           searchParameters.push(`grid-org-id:${escapedParams.institution}`)
-        } 
+        }
         //if starts with http, assume it's a ror id
         else if (escapedParams.institution.startsWith('http')) {
           searchParameters.push(`ror-org-id:${escapedParams.institution}`)
-        }
-        else {
+        } else {
           searchParameters.push(
             `affiliation-org-name:${escapedParams.institution}`
           )


### PR DESCRIPTION
ROR ids start with http, we assume that if starts with http is a ror id and map it to ror-org-id in the institution name