### PR TITLE
Added the hide reveal citations

### DIFF
--- a/src/app/record/components/work/work.component.html
+++ b/src/app/record/components/work/work.component.html
@@ -274,43 +274,70 @@
       <ng-container i18n="@@works.citation">Citation</ng-container>
       <span *ngIf="work.citation?.citationType?.value"
         >({{ work.citation?.citationType?.value }})</span
-      > 
+      >
     </h3>
     <div>
-          <div>
-            <a class="underline" (click)="showCitation = !showCitation" id="cy-citation-toggle-link">
-              <ng-container i18n="@@works.showCitation" *ngIf="!showCitation" id="cy-show-citation">
-                Show citation
-              </ng-container>
-              <ng-container i18n="@@works.hideCitation" *ngIf="showCitation"  id="cy-hide-citation">
-                Hide citation
-              </ng-container>
-            </a>
-          </div>
-          <br />
+      <div>
+        <a
+          class="underline"
+          (click)="showCitation = !showCitation"
+          id="cy-citation-toggle-link"
+        >
+          <ng-container
+            i18n="@@works.showCitation"
+            *ngIf="!showCitation"
+            id="cy-show-citation"
+          >
+            Show citation
+          </ng-container>
+          <ng-container
+            i18n="@@works.hideCitation"
+            *ngIf="showCitation"
+            id="cy-hide-citation"
+          >
+            Hide citation
+          </ng-container>
+        </a>
+      </div>
+      <br />
       <ng-container *ngIf="togglzWorksContributors">
         <ng-container
-          *ngIf="work.citation?.citation?.value?.length > maxBibtexCharacters && showCitation"
+          *ngIf="
+            work.citation?.citation?.value?.length > maxBibtexCharacters &&
+            showCitation
+          "
         >
-        <ng-container
-        *ngIf="!showExpandedFormatting"
-        >
-          {{ work.citation.citation.value.substr(0, maxBibtexCharacters) }}
-        </ng-container>
-        <ng-container *ngIf="showExpandedFormatting">
-          <pre class="pre-bibtex">{{ work.citation.citation.value | formatBibtex}} </pre>
-        </ng-container>
-        <ng-container *ngIf="work.citation?.citationType?.value ==='bibtex'">
-          <br />
-          <a class="underline" (click)="showExpandedFormatting = !showExpandedFormatting" id="cy-expanded-citation-toggle-link">
-            <ng-container i18n="@@works.expandedFormatBibtex" *ngIf="!showExpandedFormatting" id="cy-expanded-formatting">
-              Switch to expanded formatting
-            </ng-container>
-            <ng-container i18n="@@works.compactFormatBibtex" *ngIf="showExpandedFormatting" id="cy-compact-formatting">
-              Switch to compact formatting
-            </ng-container>
-          </a>
-        </ng-container>
+          <ng-container *ngIf="!showExpandedFormatting">
+            {{ work.citation.citation.value.substr(0, maxBibtexCharacters) }}
+          </ng-container>
+          <ng-container *ngIf="showExpandedFormatting">
+            <pre class="pre-bibtex"
+              >{{ work.citation.citation.value | formatBibtex }} </pre
+            >
+          </ng-container>
+          <ng-container *ngIf="work.citation?.citationType?.value === 'bibtex'">
+            <br />
+            <a
+              class="underline"
+              (click)="showExpandedFormatting = !showExpandedFormatting"
+              id="cy-expanded-citation-toggle-link"
+            >
+              <ng-container
+                i18n="@@works.expandedFormatBibtex"
+                *ngIf="!showExpandedFormatting"
+                id="cy-expanded-formatting"
+              >
+                Switch to expanded formatting
+              </ng-container>
+              <ng-container
+                i18n="@@works.compactFormatBibtex"
+                *ngIf="showExpandedFormatting"
+                id="cy-compact-formatting"
+              >
+                Switch to compact formatting
+              </ng-container>
+            </a>
+          </ng-container>
           <br />
           ----
           <br />
@@ -340,25 +367,42 @@
           </a>
         </ng-container>
         <ng-container
-          *ngIf="work?.citation?.citation?.value?.length < maxBibtexCharacters && showCitation"
+          *ngIf="
+            work?.citation?.citation?.value?.length < maxBibtexCharacters &&
+            showCitation
+          "
         >
-        <ng-container *ngIf="!showExpandedFormatting">
-          {{ work.citation.citation.value}}
-        </ng-container>
-        <ng-container *ngIf="showExpandedFormatting" >
-          <pre class="pre-bibtex">{{ work.citation.citation.value | formatBibtex}} </pre>
-        </ng-container>
-        <ng-container *ngIf="work.citation?.citationType?.value ==='bibtex'">
-          <a class="underline" (click)="showExpandedFormatting = !showExpandedFormatting" id="cy-expanded-citation-toggle-link">
-            <ng-container i18n="@@works.expandedFormatBibtex" *ngIf="!showExpandedFormatting" id="cy-expanded-formatting">
-              <br />
-              Switch to expanded formatting
-            </ng-container>
-            <ng-container i18n="@@works.compactFormatBibtex" *ngIf="showExpandedFormatting" id="cy-compact-formatting">
-              Switch to compact formatting
-            </ng-container>
-          </a>
-        </ng-container>
+          <ng-container *ngIf="!showExpandedFormatting">
+            {{ work.citation.citation.value }}
+          </ng-container>
+          <ng-container *ngIf="showExpandedFormatting">
+            <pre class="pre-bibtex"
+              >{{ work.citation.citation.value | formatBibtex }} </pre
+            >
+          </ng-container>
+          <ng-container *ngIf="work.citation?.citationType?.value === 'bibtex'">
+            <a
+              class="underline"
+              (click)="showExpandedFormatting = !showExpandedFormatting"
+              id="cy-expanded-citation-toggle-link"
+            >
+              <ng-container
+                i18n="@@works.expandedFormatBibtex"
+                *ngIf="!showExpandedFormatting"
+                id="cy-expanded-formatting"
+              >
+                <br />
+                Switch to expanded formatting
+              </ng-container>
+              <ng-container
+                i18n="@@works.compactFormatBibtex"
+                *ngIf="showExpandedFormatting"
+                id="cy-compact-formatting"
+              >
+                Switch to compact formatting
+              </ng-container>
+            </a>
+          </ng-container>
         </ng-container>
       </ng-container>
       <ng-container *ngIf="!togglzWorksContributors" && showCitation>
@@ -366,15 +410,29 @@
           {{ work.citation.citation.value }}
         </ng-container>
         <ng-container *ngIf="showExpandedFormatting">
-          <pre class="pre-bibtex">{{ work.citation.citation.value | formatBibtex}} </pre>
+          <pre class="pre-bibtex"
+            >{{ work.citation.citation.value | formatBibtex }} </pre
+          >
         </ng-container>
-        <ng-container *ngIf="work.citation?.citationType?.value ==='bibtex'">
+        <ng-container *ngIf="work.citation?.citationType?.value === 'bibtex'">
           <br />
-          <a class="underline" (click)="showExpandedFormatting = !showExpandedFormatting" id="cy-expanded-citation-toggle-link">
-            <ng-container i18n="@@works.expandedFormatBibtex" *ngIf="!showExpandedFormatting" id="cy-expanded-formatting">
+          <a
+            class="underline"
+            (click)="showExpandedFormatting = !showExpandedFormatting"
+            id="cy-expanded-citation-toggle-link"
+          >
+            <ng-container
+              i18n="@@works.expandedFormatBibtex"
+              *ngIf="!showExpandedFormatting"
+              id="cy-expanded-formatting"
+            >
               Switch to expanded formatting
             </ng-container>
-            <ng-container i18n="@@works.compactFormatBibtex" *ngIf="showExpandedFormatting" id="cy-compact-formatting">
+            <ng-container
+              i18n="@@works.compactFormatBibtex"
+              *ngIf="showExpandedFormatting"
+              id="cy-compact-formatting"
+            >
               Switch to compact formatting
             </ng-container>
           </a>

--- a/src/app/record/components/work/work.component.html
+++ b/src/app/record/components/work/work.component.html
@@ -274,15 +274,43 @@
       <ng-container i18n="@@works.citation">Citation</ng-container>
       <span *ngIf="work.citation?.citationType?.value"
         >({{ work.citation?.citationType?.value }})</span
-      >
+      > 
     </h3>
-
     <div>
+          <div>
+            <a class="underline" (click)="showCitation = !showCitation" id="cy-citation-toggle-link">
+              <ng-container i18n="@@works.showCitation" *ngIf="!showCitation" id="cy-show-citation">
+                Show citation
+              </ng-container>
+              <ng-container i18n="@@works.hideCitation" *ngIf="showCitation"  id="cy-hide-citation">
+                Hide citation
+              </ng-container>
+            </a>
+          </div>
+          <br />
       <ng-container *ngIf="togglzWorksContributors">
         <ng-container
-          *ngIf="work.citation?.citation?.value?.length > maxBibtexCharacters"
+          *ngIf="work.citation?.citation?.value?.length > maxBibtexCharacters && showCitation"
+        >
+        <ng-container
+        *ngIf="!showExpandedFormatting"
         >
           {{ work.citation.citation.value.substr(0, maxBibtexCharacters) }}
+        </ng-container>
+        <ng-container *ngIf="showExpandedFormatting">
+          <pre class="pre-bibtex">{{ work.citation.citation.value | formatBibtex}} </pre>
+        </ng-container>
+        <ng-container *ngIf="work.citation?.citationType?.value ==='bibtex'">
+          <br />
+          <a class="underline" (click)="showExpandedFormatting = !showExpandedFormatting" id="cy-expanded-citation-toggle-link">
+            <ng-container i18n="@@works.expandedFormatBibtex" *ngIf="!showExpandedFormatting" id="cy-expanded-formatting">
+              Switch to expanded formatting
+            </ng-container>
+            <ng-container i18n="@@works.compactFormatBibtex" *ngIf="showExpandedFormatting" id="cy-compact-formatting">
+              Switch to compact formatting
+            </ng-container>
+          </a>
+        </ng-container>
           <br />
           ----
           <br />
@@ -312,13 +340,45 @@
           </a>
         </ng-container>
         <ng-container
-          *ngIf="work?.citation?.citation?.value?.length < maxBibtexCharacters"
+          *ngIf="work?.citation?.citation?.value?.length < maxBibtexCharacters && showCitation"
         >
-          {{ work.citation.citation.value }}
+        <ng-container *ngIf="!showExpandedFormatting">
+          {{ work.citation.citation.value}}
+        </ng-container>
+        <ng-container *ngIf="showExpandedFormatting" >
+          <pre class="pre-bibtex">{{ work.citation.citation.value | formatBibtex}} </pre>
+        </ng-container>
+        <ng-container *ngIf="work.citation?.citationType?.value ==='bibtex'">
+          <a class="underline" (click)="showExpandedFormatting = !showExpandedFormatting" id="cy-expanded-citation-toggle-link">
+            <ng-container i18n="@@works.expandedFormatBibtex" *ngIf="!showExpandedFormatting" id="cy-expanded-formatting">
+              <br />
+              Switch to expanded formatting
+            </ng-container>
+            <ng-container i18n="@@works.compactFormatBibtex" *ngIf="showExpandedFormatting" id="cy-compact-formatting">
+              Switch to compact formatting
+            </ng-container>
+          </a>
+        </ng-container>
         </ng-container>
       </ng-container>
-      <ng-container *ngIf="!togglzWorksContributors">
-        {{ work.citation.citation.value }}
+      <ng-container *ngIf="!togglzWorksContributors" && showCitation>
+        <ng-container *ngIf="!showExpandedFormatting">
+          {{ work.citation.citation.value }}
+        </ng-container>
+        <ng-container *ngIf="showExpandedFormatting">
+          <pre class="pre-bibtex">{{ work.citation.citation.value | formatBibtex}} </pre>
+        </ng-container>
+        <ng-container *ngIf="work.citation?.citationType?.value ==='bibtex'">
+          <br />
+          <a class="underline" (click)="showExpandedFormatting = !showExpandedFormatting" id="cy-expanded-citation-toggle-link">
+            <ng-container i18n="@@works.expandedFormatBibtex" *ngIf="!showExpandedFormatting" id="cy-expanded-formatting">
+              Switch to expanded formatting
+            </ng-container>
+            <ng-container i18n="@@works.compactFormatBibtex" *ngIf="showExpandedFormatting" id="cy-compact-formatting">
+              Switch to compact formatting
+            </ng-container>
+          </a>
+        </ng-container>
       </ng-container>
     </div>
   </app-display-attribute>

--- a/src/app/record/components/work/work.component.scss
+++ b/src/app/record/components/work/work.component.scss
@@ -20,6 +20,6 @@ p {
 
 .pre-bibtex {
   font-size: inherit;
-  margin:0px;
+  margin: 0px;
   font-family: inherit;
 }

--- a/src/app/record/components/work/work.component.scss
+++ b/src/app/record/components/work/work.component.scss
@@ -17,3 +17,9 @@ p {
 .uppercase {
   text-transform: uppercase;
 }
+
+.pre-bibtex {
+  font-size: inherit;
+  margin:0px;
+  font-family: inherit;
+}

--- a/src/app/record/components/work/work.component.ts
+++ b/src/app/record/components/work/work.component.ts
@@ -39,7 +39,6 @@ export class WorkComponent implements OnInit {
   contributionRole: string
   showCitation = false
   showExpandedFormatting = false
- 
 
   constructor(
     private elementRef: ElementRef,

--- a/src/app/record/components/work/work.component.ts
+++ b/src/app/record/components/work/work.component.ts
@@ -37,6 +37,9 @@ export class WorkComponent implements OnInit {
   contributorsGroupedByOrcid: Contributor[] = []
   numberOfContributors: number
   contributionRole: string
+  showCitation = false
+  showExpandedFormatting = false
+ 
 
   constructor(
     private elementRef: ElementRef,

--- a/src/app/shared/pipes/format-bibtex/format-bibtex.pipe.spec.ts
+++ b/src/app/shared/pipes/format-bibtex/format-bibtex.pipe.spec.ts
@@ -1,4 +1,4 @@
-import { FormatBibtex} from './format-bibtex.pipe'
+import { FormatBibtex } from './format-bibtex.pipe'
 
 describe('FormatBibtexPipe', () => {
   it('create an instance', () => {

--- a/src/app/shared/pipes/format-bibtex/format-bibtex.pipe.spec.ts
+++ b/src/app/shared/pipes/format-bibtex/format-bibtex.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { FormatBibtex} from './format-bibtex.pipe'
+
+describe('FormatBibtexPipe', () => {
+  it('create an instance', () => {
+    const pipe = new FormatBibtex()
+    expect(pipe).toBeTruthy()
+  })
+})

--- a/src/app/shared/pipes/format-bibtex/format-bibtex.pipe.ts
+++ b/src/app/shared/pipes/format-bibtex/format-bibtex.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core'
+
+
+@Pipe({
+  name: 'formatBibtex',
+})
+export class FormatBibtex implements PipeTransform {
+  transform(text: string): string {
+    var bibtexParse = require('@orcid/bibtex-parse-js');
+    var formatted = bibtexParse.toBibtex(bibtexParse.toJSON(text), false)
+    return formatted.trim();
+  }
+}

--- a/src/app/shared/pipes/format-bibtex/format-bibtex.pipe.ts
+++ b/src/app/shared/pipes/format-bibtex/format-bibtex.pipe.ts
@@ -1,13 +1,12 @@
 import { Pipe, PipeTransform } from '@angular/core'
 
-
 @Pipe({
   name: 'formatBibtex',
 })
 export class FormatBibtex implements PipeTransform {
   transform(text: string): string {
-    var bibtexParse = require('@orcid/bibtex-parse-js');
+    var bibtexParse = require('@orcid/bibtex-parse-js')
     var formatted = bibtexParse.toBibtex(bibtexParse.toJSON(text), false)
-    return formatted.trim();
+    return formatted.trim()
   }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -16,6 +16,7 @@ import { ShowingOfComponent } from './components/showing-of/showing-of.component
 import { CopyOnClickDirective } from './directives/copy-on-click/copy-on-click.directive'
 import { AffiliationTypeLabelPipe } from './pipes/affiliation-type-label.pipe'
 import { CityRegionCountry } from './pipes/city-region-country/city-region-country.pipe'
+import { FormatBibtex } from './pipes/format-bibtex/format-bibtex.pipe'
 import { ContributorsPipe } from './pipes/contributors-pipe/contributors.pipe'
 import { EmailFrequencyLabelPipe } from './pipes/email-frequency-label/email-frequency-label.pipe'
 import { MonthDayYearDateToStringPipe } from './pipes/month-day-year-date-to-string/month-day-year-date-to-string.pipe'
@@ -46,6 +47,7 @@ import { VisibilityStringLabelPipe } from './pipes/visibility-string-label/visib
     CopyOnClickComponent,
     CityRegionCountry,
     ContributorsPipe,
+    FormatBibtex,
     SafeHtmlPipe,
     ShowingOfComponent,
     RecordWorkCategoryLabelPipe,
@@ -73,6 +75,7 @@ import { VisibilityStringLabelPipe } from './pipes/visibility-string-label/visib
     CopyOnClickDirective,
     MatSnackBarModule,
     CityRegionCountry,
+    FormatBibtex,
     ContributorsPipe,
     SafeHtmlPipe,
     ShowingOfComponent,

--- a/src/locale/properties/works/works.en.properties
+++ b/src/locale/properties/works/works.en.properties
@@ -171,3 +171,7 @@ works.visitWorkSource=visit the work source
 works.fullCitation=For full citation
 works.showing=Showing the first
 works.etAl=et al.
+works.showCitation=Show citation
+works.hideCitation=Hide citation
+works.expandedFormatBibtex=Switch to expanded formatting
+works.compactFormatBibtex=Switch to compact formatting

--- a/src/locale/properties/works/works.lr.properties
+++ b/src/locale/properties/works/works.lr.properties
@@ -174,3 +174,7 @@ works.fullCitation=LR
 works.fullContributorList=LR
 works.showing=LR
 works.etAl=LR
+works.showCitation=LR
+works.hideCitation=LR
+works.expandedFormatBibtex=LR
+works.compactFormatBibtex=LR

--- a/src/locale/properties/works/works.rl.properties
+++ b/src/locale/properties/works/works.rl.properties
@@ -174,3 +174,7 @@ works.fullCitation=RL
 works.fullContributorList=RL
 works.showing=RL
 works.etAl=RL
+works.showCitation=RL
+works.hideCitation=RL
+works.expandedFormatBibtex=RL
+works.compactFormatBibtex=RL

--- a/src/locale/properties/works/works.xx.properties
+++ b/src/locale/properties/works/works.xx.properties
@@ -174,3 +174,7 @@ works.fullCitation=X
 works.fullContributorList=X
 works.showing=X
 works.etAl=X
+works.showCitation=X
+works.hideCitation=X
+works.expandedFormatBibtex=X
+works.compactFormatBibtex=X


### PR DESCRIPTION
because citation-js is not a ESModule I had troubles resolving the dependencies properly. I reused the same library we already have in works to parse bibtex ( bibtex-parse-js ) and a pre tag.