### PR TITLE
Fixed the QA errors as detailed in the card

### DIFF
--- a/src/app/record/components/work/work.component.html
+++ b/src/app/record/components/work/work.component.html
@@ -317,6 +317,7 @@
           </ng-container>
           <ng-container *ngIf="work.citation?.citationType?.value === 'bibtex'">
             <br />
+            <br *ngIf="!showExpandedFormatting" />
             <a
               class="underline"
               (click)="showExpandedFormatting = !showExpandedFormatting"
@@ -326,7 +327,7 @@
                 i18n="@@works.expandedFormatBibtex"
                 *ngIf="!showExpandedFormatting"
                 id="cy-expanded-formatting"
-              ><br />
+              >
                 Switch to expanded formatting
               </ng-container>
               <ng-container
@@ -382,6 +383,7 @@
           </ng-container>
           <ng-container *ngIf="work.citation?.citationType?.value === 'bibtex'">
             <br />
+            <br *ngIf="!showExpandedFormatting"/>
             <a
               class="underline"
               (click)="showExpandedFormatting = !showExpandedFormatting"
@@ -392,9 +394,9 @@
                 *ngIf="!showExpandedFormatting"
                 id="cy-expanded-formatting"
               >
-                <br />
                 Switch to expanded formatting
               </ng-container>
+             
               <ng-container
                 i18n="@@works.compactFormatBibtex"
                 *ngIf="showExpandedFormatting"
@@ -417,6 +419,7 @@
         </ng-container>
         <ng-container *ngIf="work.citation?.citationType?.value === 'bibtex'">
           <br />
+          <br *ngIf="!showExpandedFormatting" />
           <a
             class="underline"
             (click)="showExpandedFormatting = !showExpandedFormatting"
@@ -427,7 +430,6 @@
               *ngIf="!showExpandedFormatting"
               id="cy-expanded-formatting"
             >
-              <br />
               Switch to expanded formatting
             </ng-container>
             <ng-container

--- a/src/app/record/components/work/work.component.html
+++ b/src/app/record/components/work/work.component.html
@@ -383,7 +383,7 @@
           </ng-container>
           <ng-container *ngIf="work.citation?.citationType?.value === 'bibtex'">
             <br />
-            <br *ngIf="!showExpandedFormatting"/>
+            <br *ngIf="!showExpandedFormatting" />
             <a
               class="underline"
               (click)="showExpandedFormatting = !showExpandedFormatting"
@@ -396,7 +396,7 @@
               >
                 Switch to expanded formatting
               </ng-container>
-             
+
               <ng-container
                 i18n="@@works.compactFormatBibtex"
                 *ngIf="showExpandedFormatting"

--- a/src/app/record/components/work/work.component.html
+++ b/src/app/record/components/work/work.component.html
@@ -272,7 +272,7 @@
   <app-display-attribute *ngIf="work.citation?.citation?.value?.length > 0">
     <h3 class="orc-font-body-small">
       <ng-container i18n="@@works.citation">Citation</ng-container>
-      <span *ngIf="work.citation?.citationType?.value"
+      <span *ngIf="work.citation?.citationType?.value" class="citation-type"
         >({{ work.citation?.citationType?.value }})</span
       >
     </h3>
@@ -326,7 +326,7 @@
                 i18n="@@works.expandedFormatBibtex"
                 *ngIf="!showExpandedFormatting"
                 id="cy-expanded-formatting"
-              >
+              ><br />
                 Switch to expanded formatting
               </ng-container>
               <ng-container
@@ -381,6 +381,7 @@
             >
           </ng-container>
           <ng-container *ngIf="work.citation?.citationType?.value === 'bibtex'">
+            <br />
             <a
               class="underline"
               (click)="showExpandedFormatting = !showExpandedFormatting"
@@ -426,6 +427,7 @@
               *ngIf="!showExpandedFormatting"
               id="cy-expanded-formatting"
             >
+              <br />
               Switch to expanded formatting
             </ng-container>
             <ng-container

--- a/src/app/record/components/work/work.component.scss
+++ b/src/app/record/components/work/work.component.scss
@@ -22,4 +22,9 @@ p {
   font-size: inherit;
   margin: 0px;
   font-family: inherit;
+  white-space: pre-wrap;
+}
+
+.citation-type {
+  font-weight: normal !important;
 }


### PR DESCRIPTION
in the sub-header "Citation (citation-type)", the citation type should not be in bold. Here's an example of how it should be displayed: "Citation (bibtex)"

The link "switch to expanded formatting" comes right after the end of the citation. There should be a line break between the end of the citation and the link. As seen here: capture2-citation.jpg

When a user clicks the link "switch to expanded formatting", the text of the citation should wrap into the next line. Right not it overflows the screen. As seen in: capture1-citation.jpg