### PR TITLE
style: Display selected organization hint in two lines if its longer …

### DIFF
--- a/src/app/record/components/affiliation-stacks-groups/modals/modal-affiliations/modal-affiliations.component.html
+++ b/src/app/record/components/affiliation-stacks-groups/modals/modal-affiliations/modal-affiliations.component.html
@@ -171,7 +171,9 @@
         appearance="outline"
         class="mat-form-field-min"
         id="cy-org-dd-mat-form"
-        [ngClass]="{ 'two-line-hint': selectedOrganizationFromDatabase?.value.length > 50 }"
+        [ngClass]="{
+          'two-line-hint': selectedOrganizationFromDatabase?.value.length > 50
+        }"
       >
         <input
           id="organization-input"


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [Display issue for long org names selected from typeahead](https://trello.com/c/5qgByPw5/8194-display-issue-for-long-org-names-selected-from-typeahead)