### PR TITLE
fix: Capitalize contribution role options

### DIFF
--- a/src/app/record/components/work-contributor-role/work-contributor-roles.component.html
+++ b/src/app/record/components/work-contributor-role/work-contributor-roles.component.html
@@ -33,7 +33,7 @@
                 [value]="contributionRole.key"
                 [disabled]="contributionRole.key | disableRole: role"
               >
-                {{ contributionRole.translation }}
+                {{ contributionRole.translation | titlecase }}
               </mat-option>
             </mat-select>
             <mat-error


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [[QA] Capitalize "software" contributor role dropdown option in work contributors form section](https://trello.com/c/Q76vFMz5/8213-qa-capitalize-software-contributor-role-dropdown-option-in-work-contributors-form-section)