### PR TITLE
Fix/8202 grid stop displaying grid organisation identifiers as links in the UI

### DIFF
--- a/src/app/core/record-works/record-works.service.ts
+++ b/src/app/core/record-works/record-works.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http'
 import { Injectable } from '@angular/core'
-import { EMPTY, Observable, of, ReplaySubject } from 'rxjs'
+import { BehaviorSubject, EMPTY, Observable, of, ReplaySubject } from 'rxjs'
 import {
   catchError,
   first,
@@ -51,6 +51,11 @@ export class RecordWorksService {
 
   userRecordOptions: UserRecordOptions = {}
 
+  private _$loading = new BehaviorSubject<boolean>(true)
+  public get $loading() {
+    return this._$loading.asObservable()
+  }
+
   constructor(
     private _togglz: TogglzService,
     private _http: HttpClient,
@@ -100,6 +105,7 @@ export class RecordWorksService {
     this.sortOrder = options.sort
     this.sortAsc = options.sortAsc
 
+    this._$loading.next(true)
     this._togglz
       .getStateOf('ORCID_ANGULAR_WORKS_CONTRIBUTORS')
       .pipe(
@@ -145,6 +151,7 @@ export class RecordWorksService {
           return data
         }),
         tap((data) => {
+          this._$loading.next(false)
           this.lastEmittedValue = data
           this.$workSubject.next(data)
         }),

--- a/src/app/record/components/org-identifier/org-identifier.component.html
+++ b/src/app/record/components/org-identifier/org-identifier.component.html
@@ -77,26 +77,23 @@
         class="underline"
         target="_blank"
         rel="noopener noreferrer"
-        href="{{
-            org.identifierType
-              | organizationLink: org.preferred
-          }}"
+        href="{{ org.identifierType | organizationLink: org.preferred }}"
         *ngIf="
-            org.identifierType
-              | organizationLink: org.preferred
-              | isUrlWithProtocol
-          "
+          org.identifierType
+            | organizationLink: org.preferred
+            | isUrlWithProtocol
+        "
       >
         {{ org.preferred }}
       </a>
       <ng-container
         *ngIf="
-            !(
-              org.identifierType
-              | organizationLink: org.preferred
-              | isUrlWithProtocol
-            )
-          "
+          !(
+            org.identifierType
+            | organizationLink: org.preferred
+            | isUrlWithProtocol
+          )
+        "
       >
         {{ org.preferred }}
       </ng-container>

--- a/src/app/record/components/org-identifier/org-identifier.component.html
+++ b/src/app/record/components/org-identifier/org-identifier.component.html
@@ -73,39 +73,32 @@
       class="padding-level-3"
     >
       {{ org.identifierType }}:
-      <ng-container
-        *ngIf="org.preferred && !(org.preferred | isUrlWithProtocol)"
-      >
-        <ng-container
-          *ngIf="
-            (org.identifierType | organizationLink: org.preferred) !== '';
-            else plainText
+      <a
+        class="underline"
+        target="_blank"
+        rel="noopener noreferrer"
+        href="{{
+            org.identifierType
+              | organizationLink: org.preferred
+          }}"
+        *ngIf="
+            org.identifierType
+              | organizationLink: org.preferred
+              | isUrlWithProtocol
           "
-        >
-          <a
-            class="underline"
-            target="_blank"
-            rel="noopener noreferrer"
-            href="{{ org.identifierType | organizationLink: org.preferred }}"
-          >
-            {{ org.preferred }}
-          </a>
-        </ng-container>
-        <ng-template #plainText>
-          {{ org.preferred }}
-        </ng-template>
-      </ng-container>
-      <ng-container
-        *ngIf="org.preferred && (org.preferred | isUrlWithProtocol)"
       >
-        <a
-          class="underline"
-          target="_blank"
-          rel="noreferrer noopener"
-          href="{{ org.preferred }}"
-        >
-          {{ org.preferred }}
-        </a>
+        {{ org.preferred }}
+      </a>
+      <ng-container
+        *ngIf="
+            !(
+              org.identifierType
+              | organizationLink: org.preferred
+              | isUrlWithProtocol
+            )
+          "
+      >
+        {{ org.preferred }}
       </ng-container>
       <ng-container *ngIf="org.preferred">
         <span> (</span><span i18n="@@shared.preferred">preferred</span

--- a/src/app/record/components/work-stack-group/work-stack-group.component.ts
+++ b/src/app/record/components/work-stack-group/work-stack-group.component.ts
@@ -13,7 +13,7 @@ import { MatCheckbox, MatCheckboxChange } from '@angular/material/checkbox'
 import { MatDialog } from '@angular/material/dialog'
 import { PageEvent } from '@angular/material/paginator'
 import { isEmpty } from 'lodash'
-import { Subject } from 'rxjs'
+import { Observable, Subject } from 'rxjs'
 import { first } from 'rxjs/operators'
 import { PlatformInfo, PlatformInfoService } from 'src/app/cdk/platform-info'
 import {
@@ -107,6 +107,7 @@ export class WorkStackGroupComponent implements OnInit {
   ]
 
   $destroy: Subject<boolean> = new Subject<boolean>()
+  $loading: Observable<boolean>
 
   userRecord: UserRecord
   workGroup: WorksEndpoint
@@ -133,6 +134,7 @@ export class WorkStackGroupComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.$loading = this._works.$loading
     this._record
       .getRecord({ publicRecordId: this.isPublicRecord })
       .subscribe((userRecord) => {
@@ -140,11 +142,10 @@ export class WorkStackGroupComponent implements OnInit {
         if (!isEmpty(userRecord?.works)) {
           this.paginationLoading = false
           this.workGroup = userRecord.works
-          this.total.emit(userRecord.works?.groups?.length)
           this.paginationTotalAmountOfWorks = userRecord.works.totalGroups
           this.paginationIndex = userRecord.works.pageIndex
           this.paginationPageSize = userRecord.works.pageSize
-          this.total.emit(userRecord.works.groups?.length || 0)
+          this.total.emit(userRecord.works?.groups?.length || 0)
         }
       })
     if (!this.isPublicRecord) {

--- a/src/app/shared/pipes/organization-link/organization-link.pipe.ts
+++ b/src/app/shared/pipes/organization-link/organization-link.pipe.ts
@@ -6,10 +6,12 @@ import { URL_REGEXP_BACKEND, WHITE_SPACE_REGEXP } from '../../../constants'
 })
 export class OrganizationLinkPipe implements PipeTransform {
   transform(type: string, value: string): string {
-    if (this.isUrl(value)) {
-      return value
-    } else {
-      return this.getLink(type, value)
+    if (value) {
+      if (this.isUrl(value)) {
+        return value
+      } else {
+        return this.getLink(type, value)
+      }
     }
   }
 


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [GRID - stop displaying grid organisation identifiers as links in the UI](https://trello.com/c/dDRYbWmC/8202-grid-stop-displaying-grid-organisation-identifiers-as-links-in-the-ui)