### PR TITLE
fix(work): Update unique validator to allow duplicated options

### DIFF
--- a/src/app/record/components/work-contributor-role/work-contributor-roles.component.ts
+++ b/src/app/record/components/work-contributor-role/work-contributor-roles.component.ts
@@ -136,7 +136,7 @@ export class WorkContributorRolesComponent implements OnInit {
     return this.formBuilder.group({
       role: [
         { value: role ? role.toLowerCase() : '', disabled },
-        [unique('role')],
+        [unique('role', 'no specified role')],
       ],
     })
   }

--- a/src/app/shared/validators/unique/unique.validator.ts
+++ b/src/app/shared/validators/unique/unique.validator.ts
@@ -6,7 +6,7 @@ import {
   ValidatorFn,
 } from '@angular/forms'
 
-export function unique(controlName: string): ValidatorFn {
+export function unique(controlName: string, duplicatedOptionAllowed?: string): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     if (control.value) {
       const parentFormGroup: FormArray | FormGroup = control.parent
@@ -22,7 +22,11 @@ export function unique(controlName: string): ValidatorFn {
               )
             }
             if (formGroup.value[controlName] === control.value) {
-              return { unique: true }
+              if (duplicatedOptionAllowed === control.value) {
+                return null
+              } else {
+                return { unique: true }
+              }
             }
           }
         }

--- a/src/app/shared/validators/unique/unique.validator.ts
+++ b/src/app/shared/validators/unique/unique.validator.ts
@@ -6,7 +6,10 @@ import {
   ValidatorFn,
 } from '@angular/forms'
 
-export function unique(controlName: string, duplicatedOptionAllowed?: string): ValidatorFn {
+export function unique(
+  controlName: string,
+  duplicatedOptionAllowed?: string
+): ValidatorFn {
   return (control: AbstractControl): ValidationErrors | null => {
     if (control.value) {
       const parentFormGroup: FormArray | FormGroup = control.parent


### PR DESCRIPTION
![](https://github.trello.services/images/mini-trello-icon.png) [`No specified role` should not trigger a 'multiple Credit role' error](https://trello.com/c/G12MG7m6/8239-no-specified-role-should-not-trigger-a-multiple-credit-role-error)