### PR TITLE
fix: Initialize bibtex array every time the `worksValidate` end point…

### DIFF
--- a/src/app/record/components/work-stack-group/modals/work-bibtex-modal/work-bibtex-modal.component.ts
+++ b/src/app/record/components/work-stack-group/modals/work-bibtex-modal/work-bibtex-modal.component.ts
@@ -103,6 +103,7 @@ export class WorkBibtexModalComponent implements OnInit, OnDestroy {
                       .worksValidate(newWorks)
                       .pipe(first())
                       .subscribe((data) => {
+                        that.worksFromBibtex = []
                         data.forEach((work) => {
                           that.worksFromBibtex.push(work)
                           if (work.errors.length > 0 && !that.isAnInvalidWork) {


### PR DESCRIPTION
… is called