### PR TITLE
Prevent redirecting againt in the middle of redirect (ORCID#1926)

### DIFF
--- a/src/app/guards/authorize.guard.ts
+++ b/src/app/guards/authorize.guard.ts
@@ -23,6 +23,7 @@ import { GoogleTagManagerService } from '../core/google-tag-manager/google-tag-m
 })
 export class AuthorizeGuard implements CanActivateChild {
   lastRedirectUrl: string
+  inTheMiddleOfRedirect: boolean = false
   constructor(
     private _user: UserService,
     private _router: Router,
@@ -67,7 +68,14 @@ export class AuthorizeGuard implements CanActivateChild {
   }
 
   sendUserToRedirectURL(oauthSession: RequestInfoForm): Observable<boolean> {
+    // Prevent double redirection caused by races using simple semaphore like construct
+    if (this.inTheMiddleOfRedirect) {
+      return;
+    }
+
     this.window.location.href = oauthSession.redirectUrl
+    this.inTheMiddleOfRedirect = true;
+
     return NEVER
   }
 


### PR DESCRIPTION
This should hopefully be temporary fix for issue mentioned in #1926 where some of SSO clients like OSF or our [Bridge of Knowledge](https://mostwiedzy.pl] have problems with users being unable to log in into the application. The issue is caused by the race condition of GTM and GTM timeout (4s) so as temporary solution I propose to simply allow only one call to the `sendUserToRedirectURL` which should fix the problem. 

However proper solution is needed because setting 4s timeout as workaround for users that have addons blocking GTM does not seem like proper solution causing unnecessary delay for some users.