### PR TITLE
fix: Only display `email already associated` inline error if the user…

### DIFF
--- a/src/app/register2/components/backend-error/backend-error.component.html
+++ b/src/app/register2/components/backend-error/backend-error.component.html
@@ -1,13 +1,21 @@
 <ng-container
-  *ngIf="recognizedError[errorCode] === 0 && !disableInlineAlreadyExistError"
+  *ngIf="recognizedError[errorCode] === 0"
 >
-  <ng-container i18n="@@register.emailAlreadyExists"
-    >This email already exists in our system. Would you like to</ng-container
-  >
+  <ng-container *ngIf="!registrationTogglz">
+    <ng-container i18n="@@register.emailAlreadyExists"
+      >This email already exists in our system. Would you like to</ng-container
+    >
 
-  <a (click)="navigateToSignin(value)" i18n="@@register.signinLowerCase"
-    >sign in</a
-  ><ng-container i18n="@@shared.questionMark">?</ng-container>
+    <a (click)="navigateToSignin(value)" i18n="@@register.signinLowerCase"
+      >sign in</a
+    ><ng-container i18n="@@shared.questionMark">?</ng-container>
+  </ng-container>
+
+  <ng-container *ngIf="registrationTogglz && nextButtonWasClicked">
+    <ng-container i18n="@@register.emailIsAlreadyAssociated"
+      >This email is already associated with an existing ORCID record. Please use a different email address.</ng-container
+    >
+  </ng-container>
 </ng-container>
 
 <ng-container

--- a/src/app/register2/components/backend-error/backend-error.component.ts
+++ b/src/app/register2/components/backend-error/backend-error.component.ts
@@ -8,6 +8,7 @@ import { ErrorHandlerService } from 'src/app/core/error-handler/error-handler.se
 import { SignInService } from 'src/app/core/sign-in/sign-in.service'
 import { ERROR_REPORT } from 'src/app/errors'
 import { WINDOW } from 'src/app/cdk/window'
+import { TogglzService } from '../../../core/togglz/togglz.service'
 
 // When the error text is not listed on the RegisterBackendErrors enum
 // the error message will be displayed as it comes from the backend
@@ -29,7 +30,8 @@ enum RegisterBackendErrors {
 export class BackendErrorComponent implements OnInit {
   recognizedError = RegisterBackendErrors
   _errorCode: string
-  @Input() disableInlineAlreadyExistError = false
+  @Input() nextButtonWasClicked = false
+  registrationTogglz = false
 
   @Input()
   set errorCode(errorCode: string) {
@@ -50,9 +52,14 @@ export class BackendErrorComponent implements OnInit {
     private _snackbar: SnackbarService,
     private _signIn: SignInService,
     private _errorHandler: ErrorHandlerService,
-    @Inject(WINDOW) private window: Window
+    private _togglz: TogglzService,
+  @Inject(WINDOW) private window: Window
   ) {}
   ngOnInit() {
+    this._togglz
+      .getStateOf('REGISTRATION_2_0')
+      .pipe(take(1))
+      .subscribe((value) => (this.registrationTogglz = value))
     if (!(this.errorCode in RegisterBackendErrors)) {
       this.unrecognizedError = true
     }

--- a/src/app/register2/components/form-personal/form-personal.component.html
+++ b/src/app/register2/components/form-personal/form-personal.component.html
@@ -89,10 +89,9 @@
     <div class="input-container">
       <mat-label
         class="orc-font-small-print"
-        class="orc-font-small-print"
         id="email-input-input-label"
         [ngClass]="{
-          error: emailFormTouched && emails.controls.email.errors
+          error: emailError
         }"
         id="email-input-label"
         i18n="@@register.primaryEmail"
@@ -102,7 +101,10 @@
       <mat-form-field
         appearance="outline"
         [hideRequiredMarker]="true"
-        [ngClass]="{ 'valid-password-input': emailsAreValid }"
+        [ngClass]="{
+          'valid-password-input': emailsAreValid,
+          'disable-error': !emailError
+        }"
       >
         <mat-icon *ngIf="emailsAreValid" matSuffix>done</mat-icon>
 
@@ -143,7 +145,7 @@
           *ngFor="let error of this.emails.getError('backendError', 'email')"
         >
           <app-backend-error
-            [disableInlineAlreadyExistError]="true"
+            [nextButtonWasClicked]="nextButtonWasClicked"
             [errorCode]="error"
             [value]="emails.get('email').value"
           ></app-backend-error>

--- a/src/app/register2/components/form-personal/form-personal.component.ts
+++ b/src/app/register2/components/form-personal/form-personal.component.ts
@@ -282,6 +282,15 @@ export class FormPersonalComponent extends BaseForm implements OnInit {
     return validStatus
   }
 
+  get emailError(): boolean {
+    if (this.emailFormTouched && this.emails.controls.email.errors) {
+      const backendError = this.emails.controls.email.errors?.backendError
+      return !(backendError && backendError[0] === 'orcid.frontend.verify.duplicate_email' && !this.nextButtonWasClicked);
+    }
+      return false
+  }
+
+
   private announce(announcement: string) {
     if (environment.debugger) {
       console.debug('📢' + announcement)

--- a/src/app/register2/components/register2.scss-theme.scss
+++ b/src/app/register2/components/register2.scss-theme.scss
@@ -87,6 +87,16 @@
         );
       }
     }
+
+    .disable-error {
+      .mat-form-field-outline {
+        color: rgba(0, 0, 0, 0.12) !important;
+      }
+      .mat-input-element {
+        color: black !important;
+      }
+    }
+
   }
 }
 

--- a/src/app/register2/components/register2.scss-theme.scss
+++ b/src/app/register2/components/register2.scss-theme.scss
@@ -93,7 +93,7 @@
         color: rgba(0, 0, 0, 0.12) !important;
       }
       .mat-input-element {
-        color: black !important;
+        color: $orcid-dark-primary-text !important;
       }
     }
 

--- a/src/locale/properties/register/register.en.properties
+++ b/src/locale/properties/register/register.en.properties
@@ -190,3 +190,4 @@ register.emailAreNotValid=Your emails do not match
 register.Email=Email
 register.VisibilityParties=Trusted parties
 register.emailPlaceholder=The email address you use most
+register.emailIsAlreadyAssociated=This email is already associated with an existing ORCID record. Please use a different email address.

--- a/src/locale/properties/register/register.lr.properties
+++ b/src/locale/properties/register/register.lr.properties
@@ -194,3 +194,4 @@ register.emailAreNotValid=LR
 register.confirmYourPassword=LR
 register.VisibilityParties=LR
 register.emailPlaceholder=LR
+register.emailIsAlreadyAssociated=LR

--- a/src/locale/properties/register/register.rl.properties
+++ b/src/locale/properties/register/register.rl.properties
@@ -194,3 +194,4 @@ register.emailAreNotValid=RL
 register.confirmYourPassword=RL
 register.VisibilityParties=RL
 register.emailPlaceholder=RL
+register.emailIsAlreadyAssociated=RL

--- a/src/locale/properties/register/register.xx.properties
+++ b/src/locale/properties/register/register.xx.properties
@@ -194,3 +194,4 @@ register.emailAreNotValid=X
 register.confirmYourPassword=X
 register.VisibilityParties=X
 register.emailPlaceholder=X
+register.emailIsAlreadyAssociated=X


### PR DESCRIPTION
… clicks on `next` button