### PR TITLE
Terms of use error on registration must be displayed only after the …

### DIFF
--- a/src/app/register2/components/form-terms/form-terms.component.html
+++ b/src/app/register2/components/form-terms/form-terms.component.html
@@ -1,7 +1,6 @@
 <h3 class="orc-font-body" i18n="@@register.termsOfUse">Terms of Use</h3>
 <mat-error
-  *ngIf="
-    termsOfUseWasTouched &&
+  *ngIf="this.nextButtonWasClicked &&  
     (form.hasError('required', 'termsOfUse') ||
       form.hasError('required', 'dataProcessed'))
   "

--- a/src/app/register2/components/form-terms/form-terms.component.ts
+++ b/src/app/register2/components/form-terms/form-terms.component.ts
@@ -72,7 +72,4 @@ export class FormTermsComponent extends BaseForm implements OnInit, DoCheck {
       this._errorStateMatcher.isErrorState(this.dataProcessed, null)
   }
 
-  get termsOfUseWasTouched() {
-    return this.form.controls.termsOfUse.touched || this.nextButtonWasClicked
-  }
 }


### PR DESCRIPTION
…user hit the complete registration button AND terms of use is not selected or data processing is not selected