### PR TITLE
create extended dates and add timestamps to emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.102.8 - 2024-07-24
+
+[Full Changelog](https://github.com/ORCID/orcid-angular/compare/v2.102.7...v2.102.8)
+
 ## v2.102.7 - 2024-07-24
 
 [Full Changelog](https://github.com/ORCID/orcid-angular/compare/v2.102.6...v2.102.7)

--- a/src/app/core/record-emails/record-emails.service.ts
+++ b/src/app/core/record-emails/record-emails.service.ts
@@ -211,14 +211,6 @@ export class RecordEmailsService {
     a: AssertionVisibilityString,
     b: AssertionVisibilityString
   ): number {
-    const dateA = Date.parse(
-      `${a.createdDate.year}-${a.createdDate.month}-${a.createdDate.day}`
-    )
-
-    const dateB = Date.parse(
-      `${b.createdDate.year}-${b.createdDate.month}-${b.createdDate.day}`
-    )
-
-    return dateA - dateB
+    return a.createdDate.timestamp - b.createdDate.timestamp
   }
 }

--- a/src/app/types/common.endpoint.ts
+++ b/src/app/types/common.endpoint.ts
@@ -107,6 +107,16 @@ export interface MonthDayYearDate {
   getRequiredMessage?: any
 }
 
+export interface ExtendedDate {
+  errors?: any[]
+  day?: string
+  month?: string
+  year?: string
+  timestamp?: number
+  required?: boolean
+  getRequiredMessage?: any
+}
+
 export interface Value {
   errors?: any[] // TODO is this always empty?
   value: string

--- a/src/app/types/record.endpoint.ts
+++ b/src/app/types/record.endpoint.ts
@@ -119,7 +119,6 @@ export interface AssertionVisibilityString extends AssertionBase {
   visibility?: VisibilityStrings
   action?: 'ADD' | 'UPDATE'
   createdDate?: ExtendedDate
-  lastModifiedDate?: ExtendedDate
 }
 
 export interface GroupBase {

--- a/src/app/types/record.endpoint.ts
+++ b/src/app/types/record.endpoint.ts
@@ -1,6 +1,7 @@
 import {
   Address,
   Email,
+  ExtendedDate,
   Keyword,
   MonthDayYearDate,
   OtherName,
@@ -117,6 +118,8 @@ export interface Assertion extends AssertionBase {
 export interface AssertionVisibilityString extends AssertionBase {
   visibility?: VisibilityStrings
   action?: 'ADD' | 'UPDATE'
+  createdDate?: ExtendedDate
+  lastModifiedDate?: ExtendedDate
 }
 
 export interface GroupBase {


### PR DESCRIPTION
I only used the extended date on the emails because the timestamps are only being returned in the emails endpoint