### PR TITLE
Lmendoza/9820 qa regression oauth and openid tests fail because expected error message for negative scenarios is not displayed

### DIFF
--- a/src/app/authorize/pages/authorize/authorize.component.ts
+++ b/src/app/authorize/pages/authorize/authorize.component.ts
@@ -222,14 +222,7 @@ export class AuthorizeComponent {
   ): Observable<UserSession> {
     return this.recordService.getRecord({}).pipe(
       // Only proceed if the record has userInfo, emails, and at least one affiliation
-      filter(
-        (rec: UserRecord) =>
-          !!rec &&
-          !!rec.userInfo &&
-          !!rec.emails &&
-          Array.isArray(rec.affiliations) &&
-          rec.affiliations.length > 0
-      ),
+      filter((rec: UserRecord) => !!rec && !!rec.userInfo),
       take(1),
       switchMap((validRecord) =>
         this.loginMainInterstitialsManagerService

--- a/src/app/authorize/pages/authorize/authorize.component.ts
+++ b/src/app/authorize/pages/authorize/authorize.component.ts
@@ -7,6 +7,7 @@ import {
   finalize,
   first,
   map,
+  mapTo,
   switchMap,
   take,
   tap,
@@ -73,41 +74,27 @@ export class AuthorizeComponent {
    */
   ngOnInit(): void {
     this.loading = true
+    let currentSession: UserSession | null = null
 
     forkJoin({
       platform: this.loadPlatformInfo(),
       userSession: this.loadUserSession(),
-      userRecord: this.recordService.getRecord({}).pipe(
-        filter((userRecord: UserRecord) => {
-          return (
-            !!userRecord &&
-            !!userRecord?.userInfo &&
-            !!userRecord?.emails &&
-            !!userRecord?.affiliations?.length
-          )
-        }),
-        take(1)
-      ),
     })
       .pipe(
-        switchMap((record) => {
-          return this.loginMainInterstitialsManagerService
-            .checkLoginInterstitials(record.userRecord, {
-              returnType: 'component',
-              togglzPrefix: 'OAUTH',
-            })
-            .pipe(
-              take(1),
-              map((interstitial) => {
-                this.interstitialComponent = interstitial
-              }),
-              switchMap(() => {
-                return of(record.userSession)
-              }),
-              finalize(() => {
-                this.handleUserSession(record.userSession)
-              })
-            )
+        // Keep a copy of userSession for finalize()
+        tap(({ userSession }) => (currentSession = userSession)),
+
+        // If logged in, fetch record → check interstitials; otherwise skip straight to oauth session handling
+        switchMap(({ userSession }) =>
+          userSession.loggedIn
+            ? this.loadRecordAndCheckInterstitials(userSession)
+            : of(userSession)
+        ),
+
+        // Always run this at the end, regardless of path
+        finalize(() => {
+          this.handleOauthSession(currentSession)
+          this.loading = false
         })
       )
       .subscribe()
@@ -194,7 +181,7 @@ export class AuthorizeComponent {
    * After loading forkJoin data, decide on final flow:
    * show error, show domain interstitial, or show authorization screen.
    */
-  private handleUserSession(userSession: UserSession): void {
+  private handleOauthSession(userSession: UserSession): void {
     this.oauthSession = userSession.oauthSession
 
     // 1. If the backend returned an error
@@ -224,6 +211,40 @@ export class AuthorizeComponent {
     // 3. Otherwise, show the standard authorization component
     this.showAuthorizationComponent = true
     this.loading = false
+  }
+
+  /**
+   * Fetches a valid UserRecord, then runs checkLoginInterstitials,
+   * and finally emits the original UserSession.
+   */
+  private loadRecordAndCheckInterstitials(
+    session: UserSession
+  ): Observable<UserSession> {
+    return this.recordService.getRecord({}).pipe(
+      // Only proceed if the record has userInfo, emails, and at least one affiliation
+      filter(
+        (rec: UserRecord) =>
+          !!rec &&
+          !!rec.userInfo &&
+          !!rec.emails &&
+          Array.isArray(rec.affiliations) &&
+          rec.affiliations.length > 0
+      ),
+      take(1),
+      switchMap((validRecord) =>
+        this.loginMainInterstitialsManagerService
+          .checkLoginInterstitials(validRecord, {
+            returnType: 'component',
+            togglzPrefix: 'OAUTH',
+          })
+          .pipe(
+            take(1),
+            tap((interstitial) => (this.interstitialComponent = interstitial)),
+            // After setting up interstitials, pass the original session back downstream
+            mapTo(session)
+          )
+      )
+    )
   }
 
   /**


### PR DESCRIPTION
https://trello.com/c/71QW0t9A/9820-qa-regression-oauth-and-openid-tests-fail-because-expected-error-message-for-negative-scenarios-is-not-displayed