### PR TITLE
fix: copy projects/ directory into Docker builds

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -19,6 +19,7 @@ COPY *.json .
 COPY *.lock .
 
 COPY ./src ./src
+COPY ./projects ./projects
 
 RUN mvn -T 1C --batch-mode \
               -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \

--- a/Dockerfile.build.yarn
+++ b/Dockerfile.build.yarn
@@ -12,6 +12,8 @@ COPY src/ src/
 
 COPY scripts/ scripts/
 
+COPY projects/ projects/
+
 # RUN apk add gettext
 
 RUN yarn build


### PR DESCRIPTION
## Problem

The Docker build (`docker-compose.build.yml`) was failing because `Dockerfile.build` (and `Dockerfile.build.yarn`) never copied the `projects/` directory into the build container. The `@orcid/ui`, `@orcid/registry-ui`, and `@orcid/tokens` libraries live under `projects/` and are resolved via path mappings in `tsconfig.json`, so the Angular compiler couldn't find them:

```
Cannot find module '@orcid/ui' or its corresponding type declarations.
```

GitHub CI was unaffected because it checks out the full repo and builds directly on the filesystem — no Docker layer involved.

## Fix

Added `COPY ./projects ./projects` to both Dockerfiles so the library source is available at build time:

- **`Dockerfile.build`** — added after `COPY ./src ./src`, before the `mvn package` step
- **`Dockerfile.build.yarn`** — added after `COPY scripts/ scripts/`, before `RUN yarn build`